### PR TITLE
feat: Target ES5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "ES2015",                    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "ES5",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                  /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                          /* Specify library files to be included in the compilation. */
     "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
 [`adv-adcentre-sso`](https://github.com/SEEK-Jobs/adv-adcentre-sso) module was updated to use `tsconfig-seek` to conform with other typescript libraries at SEEK. And also potentially to pave the way for the use of the SEEK Module Toolkit. However when the new SSO library version was integrated with `adv-adcentre-ui` this caused a production incident which affected IE11 users. Specifically, this was due to the presence of backticks, which caused a syntax error in legacy browsers. 

The fix applied to the SSO repo is here: https://github.com/SEEK-Jobs/adv-adcentre-sso/blob/master/tsconfig.json#L6

Now I am looking to integrate this fix with the organisation tsconfig in order to avoid potential further production incidents for other teams. And also to raise a discussion around it.