### PR TITLE
Remove Prettier Write

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "release": "changeset publish",
     "test": "tsc --noEmit",
-    "changeset-version": "changeset version && prettier --write ."
+    "changeset-version": "changeset version"
   },
   "packageManager": "pnpm@7.27.1",
   "volta": {


### PR DESCRIPTION
Didn't realise the release script had this. https://github.com/seek-oss/tsconfig-seek/pull/9/commits/68755596d043c4cbcd84c0e5ee8ab491c727a39c


We can either add it or remove it 🤷 This repo doesn't do much so I don't see why we need it.